### PR TITLE
Update Freedesktop categories

### DIFF
--- a/Config.cmake
+++ b/Config.cmake
@@ -4,7 +4,7 @@
 # Essential, non translatable application information (except DESCRIPTION).
 # Translatable strings are passed via code.
 #===============================================================================
-list(APPEND PROJECT_CATEGORIES "Qt;Utility") # Freedesktop menu categories
+list(APPEND PROJECT_CATEGORIES "Qt;Settings;DesktopSettings") # Freedesktop menu categories
 list(APPEND PROJECT_KEYWORDS   "sddm;settings;configurator")
 set(PROJECT_AUTHOR_NAME        "Andrea Zanellato")
 set(PROJECT_AUTHOR_EMAIL       "redtid3@gmail.com") # Used also for organization email


### PR DESCRIPTION
Currently, the main Freedesktop category used is "Utility" ("Small utility application, 'Accessories'" according to Freedesktop's description). This is where we find things (at least in LXQt) like Featherpad editor and PCManFM-Qt file manager. 

On the other hand, "Settings" ("Settings applications") and the additional category of "DesktopSettings" ("Configuration tool for the GUI") is used for things like ObConf-Qt Openbox configuration editor and LXQt configuration center. 

This makes sddm-conf much more consistent.